### PR TITLE
Security gems update Q3/2020

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@
 source 'https://rubygems.org'
 
 gem 'active-fedora', '~> 13.2.0'
-gem 'active_fedora-noid'
 gem 'active-triples'
 gem 'blacklight'
 gem 'hydra-head', '~> 11.0.0'
+gem 'noid-rails', '~> 3.0.2'
 gem 'nom-xml'
 gem 'om', '~> 3.1.0'
 gem 'qa', '~> 5.4.0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@
 source 'https://rubygems.org'
 
 gem 'active-fedora', '~> 13.2.0'
-gem 'active-triples'
 gem 'active_fedora-noid'
+gem 'active-triples'
 gem 'blacklight'
 gem 'hydra-head', '~> 11.0.0'
 gem 'nom-xml'
@@ -38,7 +38,6 @@ gem 'dotenv-rails', groups: %i[development test production]
 gem 'kaminari', '>= 1.2.1'
 gem 'loofah', '>= 2.3.1'
 gem 'nokogiri', '>= 1.10.8'
-gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'websocket-extensions', '>= 0.1.5'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
@@ -51,7 +50,6 @@ group :development do
 end
 
 group :development, :test do
-  gem 'jettywrapper'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rspec-rails'
@@ -59,4 +57,7 @@ group :development, :test do
   gem 'thin'
 end
 
-gem 'swagger-docs'
+group :doc do
+  gem 'sdoc'
+  gem 'swagger-docs'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,8 +89,6 @@ GEM
     builder (3.2.4)
     byebug (11.0.1)
     cancancan (1.17.0)
-    childprocess (1.0.1)
-      rake (< 13.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
@@ -147,11 +145,6 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
-    jettywrapper (2.0.5)
-      activesupport (>= 3.0.0)
-      childprocess
-      i18n
-      rubyzip (~> 1.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -161,7 +154,6 @@ GEM
       turbolinks
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    json (1.8.6)
     json-canonicalization (0.2.0)
     json-ld (3.1.4)
       htmlentities (~> 4.3)
@@ -285,7 +277,7 @@ GEM
       rdf (~> 3.1, >= 3.1.2)
     rdf-vocab (3.1.4)
       rdf (~> 3.1)
-    rdoc (4.3.0)
+    rdoc (6.2.1)
     ref (2.0.0)
     responders (3.0.0)
       actionpack (>= 5.0)
@@ -311,7 +303,6 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     ruby-progressbar (1.10.1)
-    rubyzip (1.2.2)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -326,9 +317,8 @@ GEM
     sassc (2.4.0)
       ffi (~> 1.9)
     scanf (1.0.0)
-    sdoc (0.4.2)
-      json (~> 1.7, >= 1.7.7)
-      rdoc (~> 4.0)
+    sdoc (1.1.0)
+      rdoc (>= 5.0)
     slop (4.8.2)
     solrizer (3.4.1)
       activesupport
@@ -401,7 +391,6 @@ DEPENDENCIES
   dotenv-rails
   hydra-head (~> 11.0.0)
   jbuilder (~> 2.0)
-  jettywrapper
   jquery-rails
   jquery-turbolinks
   jquery-ui-rails
@@ -417,7 +406,7 @@ DEPENDENCIES
   rsolr
   rspec-rails
   sass-rails (~> 5.0)
-  sdoc (~> 0.4.0)
+  sdoc
   solrizer
   spring
   sprockets (~> 3.7.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,9 +40,6 @@ GEM
       activesupport (>= 3.0.0)
       rdf (>= 2.0.2, < 4.0)
       rdf-vocab (>= 2.0, < 4.0)
-    active_fedora-noid (0.1.0)
-      active-fedora
-      noid
     activejob (5.2.4.3)
       activesupport (= 5.2.4.3)
       globalid (>= 0.3.6)
@@ -90,7 +87,7 @@ GEM
     byebug (11.0.1)
     cancancan (1.17.0)
     coderay (1.1.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     crass (1.0.6)
     daemons (1.3.1)
     deprecation (1.0.0)
@@ -108,7 +105,8 @@ GEM
     dotenv-rails (2.7.2)
       dotenv (= 2.7.2)
       railties (>= 3.2, < 6.1)
-    ebnf (2.1.0)
+    ebnf (2.1.1)
+      htmlentities (~> 4.3)
       rdf (~> 3.1)
       scanf (~> 1.0)
       sxp (~> 1.1)
@@ -206,6 +204,9 @@ GEM
     multipart-post (2.1.1)
     nio4r (2.5.2)
     noid (0.9.0)
+    noid-rails (3.0.2)
+      actionpack (>= 5.0.0, < 7)
+      noid (~> 0.9)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     nom-xml (1.1.0)
@@ -267,7 +268,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rdf (3.1.4)
+    rdf (3.1.5)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-isomorphic (3.1.0)
@@ -383,7 +384,6 @@ PLATFORMS
 DEPENDENCIES
   active-fedora (~> 13.2.0)
   active-triples
-  active_fedora-noid
   blacklight
   brakeman
   devise (>= 4.7.1)
@@ -396,6 +396,7 @@ DEPENDENCIES
   jquery-ui-rails
   kaminari (>= 1.2.1)
   loofah (>= 2.3.1)
+  noid-rails (~> 3.0.2)
   nokogiri (>= 1.10.8)
   nom-xml
   om (~> 3.1.0)

--- a/app/models/concerns/assign_id.rb
+++ b/app/models/concerns/assign_id.rb
@@ -2,7 +2,7 @@ module AssignId
   extend ActiveSupport::Concern
 
   included do
-    require 'active_fedora/noid'
+    require 'noid-rails'
   end
 
   # Called automatically by the noid service
@@ -25,8 +25,8 @@ module AssignId
   end
 
   private
-  def noid_service
-    @noid_service ||= ActiveFedora::Noid::Service.new
-  end
 
+  def noid_service
+    @noid_service ||= Noid::Rails::Service.new
+  end
 end

--- a/app/models/folio.rb
+++ b/app/models/folio.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_fedora/noid'
+# require 'active_fedora/noid'
 
 class Folio < ActiveFedora::Base
   include AssignRdfTypes

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,4 +1,4 @@
-require 'active_fedora/noid'
+# require 'active_fedora/noid'
 
 # This is a VRA image, NOT a VRA work
 # TODO model how to deal with different types of image, including alternative versions and different file types
@@ -6,11 +6,15 @@ require 'active_fedora/noid'
 # For Mellon, we'll be using RDFSource, with a link to the image file in F3
 
 class Image < ActiveFedora::Base
-  include DCTerms,RdfType,SkosLabels,AssignId,AssignRdfTypes
+  include AssignRdfTypes
+  include AssignId
+  include SkosLabels
+  include RdfType
+  include DCTerms
 
   belongs_to :folio, predicate: ::RDF::URI.new('http://www.w3.org/ns/oa#hasTarget')
   has_and_belongs_to_many :registers, predicate: ::RDF::URI.new('http://dlib.york.ac.uk/ontologies/generic#referenceImage')
-  directly_contains :files, has_member_relation: ::RDF::URI.new("http://pcdm.org/models#hasFile"), class_name: 'ContainedFile'
+  directly_contains :files, has_member_relation: ::RDF::URI.new('http://pcdm.org/models#hasFile'), class_name: 'ContainedFile'
 
   # VALUE: http://www.shared-canvas.org/ns/painting
   property :motivated_by, predicate: ::RDF::Vocab::OA.motivatedBy, multiple: false do |index|

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -1,4 +1,4 @@
-require 'active_fedora/noid'
+# require 'active_fedora/noid'
 
 class Manifest < ActiveFedora::File
   include ActiveFedora::WithMetadata,AssignId

--- a/bin/spring
+++ b/bin/spring
@@ -1,18 +1,17 @@
 #!/usr/bin/env ruby
 
-# This file loads spring without using Bundler, in order to be fast
-# It gets overwritten when you run the `spring binstub` command
+# This file loads spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
-  require "rubygems"
-  require "bundler"
+  require 'rubygems'
+  require 'bundler'
 
-  if match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m)
-    ENV["GEM_PATH"] = ([Bundler.bundle_path.to_s] + Gem.path).join(File::PATH_SEPARATOR)
-    ENV["GEM_HOME"] = nil
-    Gem.paths = ENV
-
-    gem "spring", match[1]
-    require "spring/binstub"
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
+    require 'spring/binstub'
   end
 end

--- a/config/initializers/active_fedora_general.rb
+++ b/config/initializers/active_fedora_general.rb
@@ -1,0 +1,12 @@
+require 'noid-rails'
+
+# 2+ [(".reeddeeddk".gsub(/\.[rsz]/, '').length.to_f / 2).ceil, 4].min
+# 2 + [(Noid::Rails::Config.template.gsub(/\.[rsz]/, '').length.to_f / 2).ceil, 4].min
+baseparts = 6
+baseurl = "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}"
+ActiveFedora::Base.translate_uri_to_id = lambda do |uri|
+  uri.to_s.sub(baseurl, '').split('/', baseparts).last
+end
+ActiveFedora::Base.translate_id_to_uri = lambda do |id|
+  "#{baseurl}/#{Noid::Rails.treeify(id)}"
+end

--- a/config/initializers/noid-rails.rb
+++ b/config/initializers/noid-rails.rb
@@ -1,6 +1,6 @@
-require 'active_fedora/noid'
+require 'noid-rails'
 
-ActiveFedora::Noid.configure do |config|
+Noid::Rails.configure do |config|
   # Specify a different template for your repository's NOID IDs
   # To use ':' the namespace must be set in Fedora (fedora-node-types.cnd)
   # config.template = 'test:.zd'
@@ -8,6 +8,3 @@ ActiveFedora::Noid.configure do |config|
   # 30/9/2015 - agreed to use default noids
   config.statefile = ENV['NOID_PATH'] + 'noid-minter-state'
 end
-
-ActiveFedora::Base.translate_uri_to_id = ActiveFedora::Noid.config.translate_uri_to_id
-ActiveFedora::Base.translate_id_to_uri = ActiveFedora::Noid.config.translate_id_to_uri


### PR DESCRIPTION
- Use noid-rails instead of a deprecated active_fedora-noid  gem.
- Remove unused gem dependencies 